### PR TITLE
fix if statement when query arguments have value 0

### DIFF
--- a/singletons/query.php
+++ b/singletons/query.php
@@ -25,7 +25,7 @@ class JSON_API_Query {
     $wp_query_var = $this->wp_query_var($key);
     if ($wp_query_var) {
       return $wp_query_var;
-    } else if ($query_var) {
+    } else if (isset($query_var)) {
       return $this->strip_magic_quotes($query_var);
     } else if (isset($this->defaults[$key])) {
       return $this->defaults[$key];


### PR DESCRIPTION
When $key from $_REQUEST have value '0' then else if statement doesn't work in line 28. So I change from
28. } else if (($query_var)) {
to
28. } else if (isset($query_var)) {
